### PR TITLE
KAA-1655: Fix unescaped binary data in resulting string of GenericData.toString().

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target
 /build
 test-output
 /dist
+*.iml
+.idea/*

--- a/lang/java/archetypes/avro-service-archetype/pom.xml
+++ b/lang/java/archetypes/avro-service-archetype/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-archetypes-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/archetypes/pom.xml
+++ b/lang/java/archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-parent</artifactId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -146,6 +146,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/lang/java/avro/pom.xml
+++ b/lang/java/avro/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/avro/src/main/java/org/apache/avro/io/DecoderFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/DecoderFactory.java
@@ -269,6 +269,44 @@ public class DecoderFactory {
   }
 
   /**
+   * Creates a {@link JsonDecoder} using the InputStrim provided for reading
+   * data that conforms to the Schema provided.
+   * <p/>
+   *
+   * @param schema
+   *          The Schema for data read from this JsonEncoder. Cannot be null.
+   * @param input
+   *          The InputStream to read from. Cannot be null.
+   * @param decodeBase64
+   *          Decode byte arrays with Base64.
+   * @return A JsonEncoder configured with <i>input</i> and <i>schema</i>
+   * @throws IOException
+   */
+  public JsonDecoder jsonDecoder(Schema schema, InputStream input, boolean decodeBase64)
+          throws IOException {
+    return new JsonDecoder(schema, input, decodeBase64);
+  }
+
+  /**
+   * Creates a {@link JsonDecoder} using the String provided for reading data
+   * that conforms to the Schema provided.
+   * <p/>
+   *
+   * @param schema
+   *          The Schema for data read from this JsonEncoder. Cannot be null.
+   * @param input
+   *          The String to read from. Cannot be null.
+   * @param decodeBase64
+   *          Decode byte arrays with Base64.
+   * @return A JsonEncoder configured with <i>input</i> and <i>schema</i>
+   * @throws IOException
+   */
+  public JsonDecoder jsonDecoder(Schema schema, String input, boolean decodeBase64)
+          throws IOException {
+    return new JsonDecoder(schema, input, decodeBase64);
+  }
+
+  /**
    * Creates a {@link ValidatingDecoder} wrapping the Decoder provided. This
    * ValidatingDecoder will ensure that operations against it conform to the
    * schema provided.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/EncoderFactory.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/EncoderFactory.java
@@ -304,6 +304,54 @@ public class EncoderFactory {
   }
   
   /**
+   * Creates a {@link JsonEncoder} using the OutputStream provided for writing
+   * data conforming to the Schema provided with optional pretty printing.
+   * <p/>
+   * {@link JsonEncoder} buffers its output. Data may not appear on the
+   * underlying OutputStream until {@link Encoder#flush()} is called.
+   * <p/>
+   * {@link JsonEncoder} is not thread-safe.
+   *
+   * @param schema
+   *          The Schema for data written to this JsonEncoder. Cannot be null.
+   * @param out
+   *          The OutputStream to write to. Cannot be null.
+   * @param encodeBase64
+   *          Encode byte arrays with Base64.
+   * @return A JsonEncoder configured with <i>out</i>, <i>schema</i> and <i>pretty</i>
+   * @throws IOException
+   */
+  public JsonEncoder jsonEncoder(Schema schema, OutputStream out, boolean encodeBase64)
+          throws IOException {
+    return new JsonEncoder(schema, out, encodeBase64);
+  }
+
+  /**
+   * Creates a {@link JsonEncoder} using the {@link JsonGenerator} provided for
+   * output of data conforming to the Schema provided.
+   * <p/>
+   * {@link JsonEncoder} buffers its output. Data may not appear on the
+   * underlying output until {@link Encoder#flush()} is called.
+   * <p/>
+   * {@link JsonEncoder} is not thread-safe.
+   *
+   * @param schema
+   *          The Schema for data written to this JsonEncoder. Cannot be null.
+   * @param gen
+   *          The JsonGenerator to write with. Cannot be null.
+   * @param encodeBase64
+   *          Encode byte arrays with Base64.
+   * @return A JsonEncoder configured with <i>gen</i> and <i>schema</i>
+   * @throws IOException
+   * @deprecated internal method
+   */
+  @Deprecated
+  public JsonEncoder jsonEncoder(Schema schema, JsonGenerator gen, boolean encodeBase64)
+          throws IOException {
+    return new JsonEncoder(schema, gen, encodeBase64);
+  }
+
+  /**
    * Creates a {@link ValidatingEncoder} that wraps the Encoder provided.
    * This ValidatingEncoder will ensure that operations against it conform
    * to the schema provided.

--- a/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
+++ b/lang/java/avro/src/main/java/org/apache/avro/io/JsonDecoder.java
@@ -23,11 +23,12 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Stack;
+import java.util.ArrayList;
+import java.util.Base64;
 
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
@@ -54,7 +55,8 @@ public class JsonDecoder extends ParsingDecoder
   private JsonParser in;
   private static JsonFactory jsonFactory = new JsonFactory();
   Stack<ReorderBuffer> reorderBuffers = new Stack<ReorderBuffer>();
-  ReorderBuffer currentReorderBuffer; 
+  ReorderBuffer currentReorderBuffer;
+  private boolean decodeBase64 = false;
   
   private static class ReorderBuffer {
     public Map<String, List<JsonElement>> savedFields = new HashMap<String, List<JsonElement>>();
@@ -79,6 +81,16 @@ public class JsonDecoder extends ParsingDecoder
   
   JsonDecoder(Schema schema, String in) throws IOException {
     this(getSymbol(schema), in);
+  }
+
+  JsonDecoder(Schema schema, InputStream in, boolean decodeBase64) throws IOException {
+    this(getSymbol(schema), in);
+    this.decodeBase64 = decodeBase64;
+  }
+
+  JsonDecoder(Schema schema, String in, boolean decodeBase64) throws IOException {
+    this(getSymbol(schema), in);
+    this.decodeBase64 = decodeBase64;
   }
   
   private static Symbol getSymbol(Schema schema) {
@@ -261,7 +273,12 @@ public class JsonDecoder extends ParsingDecoder
   }
 
   private byte[] readByteArray() throws IOException {
-    byte[] result = in.getText().getBytes(CHARSET);
+    byte[] result;
+    if (decodeBase64) {
+      result = Base64.getDecoder().decode(in.getText());
+    } else {
+      result = in.getText().getBytes(CHARSET);
+    }
     return result;
   }
 

--- a/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/generic/TestGenericData.java
@@ -17,33 +17,35 @@
  */
 package org.apache.avro.generic;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Collection;
-import java.util.ArrayDeque;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.io.BinaryData;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
-import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.util.Utf8;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.ObjectMapper;
-
 import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 public class TestGenericData {
   
@@ -316,6 +318,45 @@ public class TestGenericData {
     
     // will throw exception if string is not parsable json
     mapper.readTree(parser);
+  }
+
+
+  @Test
+  public void testToStringWithByteArray() throws IOException {
+    final byte[] bytes = {-128, -117, -114, -103, -78, -53, -27, -26, -25, -13, -7, -2, -1, 0, 1, 2, 3, 17, 18, 19, 20, 48, 74, 100, 108, 109, 110, 125, 126};
+    String hexEquivalent  = "808b8e99b2cbe5e6e7f3f9feff0001020311121314304a646c6d6e7d7e";
+
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    String toStringResult = (new GenericData()).toString(buffer);
+
+    assertTrue(toStringResult.contains(hexEquivalent));
+  }
+
+  @Test
+  public void testToStringNotAffectsByteBuffer() throws IOException {
+    byte[] bytes = new byte[256];
+    for (byte b = Byte.MIN_VALUE; b < Byte.MAX_VALUE; b++) {
+      bytes[b - Byte.MIN_VALUE] = b;
+    }
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    ByteBuffer buffer_copy;
+
+    int testStep = 17;
+    for (int pos =  0; pos < bytes.length; pos = pos + testStep) {
+      buffer.position(pos);
+      buffer_copy = buffer.duplicate();
+
+      String stringed = (new GenericData()).toString(buffer);
+      System.out.println("OK. Position = " + pos);
+
+      assertEquals(buffer, buffer_copy);
+      assertEquals(buffer.array(), buffer_copy.array());
+      assertEquals(buffer.arrayOffset(), buffer_copy.arrayOffset());
+      assertEquals(buffer.position(), buffer_copy.position());
+      assertEquals(buffer.order(), buffer_copy.order());
+      assertEquals(buffer.capacity(), buffer_copy.capacity());
+      assertEquals(buffer.limit(), buffer_copy.limit());
+    }
   }
 
   @Test

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestEncoders.java
@@ -26,6 +26,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
@@ -191,6 +192,29 @@ public class TestEncoders {
     Decoder decoder = DecoderFactory.get().jsonDecoder(writerSchema, value);
     Object o = reader.read(null, decoder);
     Assert.assertEquals("{\"a\": {\"a1\": null, \"a2\": true}}", o.toString());
+  }
+
+  @Test public void testJsonEncodingBase64() throws Exception {
+    String schemaSrc = "{\"type\":\"record\",\"name\":\"SampleConfiguration\",\"namespace\":\"org.kaaproject.kaa.demo.configuration\",\"fields\":[{\"name\":\"AddressList\",\"type\":[{\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"Link\",\"fields\":[{\"name\":\"label\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"},\"displayName\":\"Site label\"},{\"name\":\"url\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"},\"displayName\":\"Site URL\"},{\"name\":\"__uuid\",\"type\":[{\"type\":\"fixed\",\"name\":\"uuidT\",\"namespace\":\"org.kaaproject.configuration\",\"size\":16},\"null\"],\"displayName\":\"Record Id\",\"fieldAccess\":\"read_only\"}],\"displayName\":\"Site address\"}},\"null\"],\"displayName\":\"URLs list\"},{\"name\":\"__uuid\",\"type\":[\"org.kaaproject.configuration.uuidT\",\"null\"],\"displayName\":\"Record Id\",\"fieldAccess\":\"read_only\"}]}";
+    Schema schema = new Schema.Parser().parse(schemaSrc);
+    //getting record to encode
+    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<GenericRecord>(schema);
+    String recordWithLatin1 = "{\"AddressList\":{\"array\":[{\"label\":\"Kaa website\",\"url\":\"http://www.kaaproject.org\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"à\\u0001§ï\u0081yIã»g?ßòõ,\\u0017\"}},{\"label\":\"Kaa GitHub repository\",\"url\":\"https://github.com/kaaproject/kaa\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"}\\u001A\\u001A\u009E\\u0013£DÅ»\\be\\u0016We\\bð\"}},{\"label\":\"Kaa docs\",\"url\":\"http://docs.kaaproject.org/display/KAA/Kaa+IoT+Platform+Home\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"¢\\\\\u008Bæf»J\u0092\u0093\u0091\\u0019ÝŽJù\\\"\"}},{\"label\":\"Kaa configuration design reference\",\"url\":\"http://docs.kaaproject.org/display/KAA/Configuration\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"!ÙpQ\\u0018iNy\u0095Sj\u0081§\u007F$\u0082\"}},{\"label\":\"Hello world\",\"url\":\"http://hello.world\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"8Ž\\bŸ\u008EÐO7\u0097\u008Aæv\u009E|Ž\u0099\"}}]},\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"Jç]\u008F:¶@\\u0002\u0086>n^ÿ\\u0010×Ù\"}}";
+    JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(schema, recordWithLatin1);
+    DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>(schema);
+    GenericRecord record = datumReader.read(null, jsonDecoder);
+    //encoding
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    Encoder jsonEncoder = EncoderFactory.get().jsonEncoder(schema, baos, true);
+    datumWriter.write(record, jsonEncoder);
+    jsonEncoder.flush();
+    baos.flush();
+    byte[] bytes = baos.toByteArray();
+    String actual = new String(bytes);
+
+    String expected = "{\"AddressList\":{\"array\":[{\"label\":\"Kaa website\",\"url\":\"http://www.kaaproject.org\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"4AGn74F5SeO7Zz/f8vUsFw==\"}},{\"label\":\"Kaa GitHub repository\",\"url\":\"https://github.com/kaaproject/kaa\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"fRoanhOjRMW7CGUWV2UI8A==\"}},{\"label\":\"Kaa docs\",\"url\":\"http://docs.kaaproject.org/display/KAA/Kaa+IoT+Platform+Home\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"olyL5ma7SpKTkRndP0r5Ig==\"}},{\"label\":\"Kaa configuration design reference\",\"url\":\"http://docs.kaaproject.org/display/KAA/Configuration\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"IdlwURhpTnmVU2qBp38kgg==\"}},{\"label\":\"Hello world\",\"url\":\"http://hello.world\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"OD8IP47QTzeXiuZ2nnw/mQ==\"}}]},\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"Suddjzq2QAKGPm5e/xDX2Q==\"}}";
+    Assert.assertNotNull("Resulting string shouldn't be null", actual);
+    Assert.assertEquals("Actual result of encoding is not equal to expected", expected, actual);
   }
 
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestJsonDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestJsonDecoder.java
@@ -60,4 +60,18 @@ public class TestJsonDecoder {
     }
   }
 
+  @Test public void testDecodingBase64() throws Exception {
+    String schemaSrc = "{\"type\":\"record\",\"name\":\"SampleConfiguration\",\"namespace\":\"org.kaaproject.kaa.demo.configuration\",\"fields\":[{\"name\":\"AddressList\",\"type\":[{\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"Link\",\"fields\":[{\"name\":\"label\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"},\"displayName\":\"Site label\"},{\"name\":\"url\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"},\"displayName\":\"Site URL\"},{\"name\":\"__uuid\",\"type\":[{\"type\":\"fixed\",\"name\":\"uuidT\",\"namespace\":\"org.kaaproject.configuration\",\"size\":16},\"null\"],\"displayName\":\"Record Id\",\"fieldAccess\":\"read_only\"}],\"displayName\":\"Site address\"}},\"null\"],\"displayName\":\"URLs list\"},{\"name\":\"__uuid\",\"type\":[\"org.kaaproject.configuration.uuidT\",\"null\"],\"displayName\":\"Record Id\",\"fieldAccess\":\"read_only\"}]}";
+    Schema schema = new Schema.Parser().parse(schemaSrc);
+    String encoded = "{\"AddressList\":{\"array\":[{\"label\":\"Kaa website\",\"url\":\"http://www.kaaproject.org\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"4AGn74F5SeO7Zz/f8vUsFw==\"}},{\"label\":\"Kaa GitHub repository\",\"url\":\"https://github.com/kaaproject/kaa\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"fRoanhOjRMW7CGUWV2UI8A==\"}},{\"label\":\"Kaa docs\",\"url\":\"http://docs.kaaproject.org/display/KAA/Kaa+IoT+Platform+Home\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"olyL5ma7SpKTkRndP0r5Ig==\"}},{\"label\":\"Kaa configuration design reference\",\"url\":\"http://docs.kaaproject.org/display/KAA/Configuration\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"IdlwURhpTnmVU2qBp38kgg==\"}},{\"label\":\"Hello world\",\"url\":\"http://hello.world\",\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"OD8IP47QTzeXiuZ2nnw/mQ==\"}}]},\"__uuid\":{\"org.kaaproject.configuration.uuidT\":\"Suddjzq2QAKGPm5e/xDX2Q==\"}}";
+    boolean base64 = true;
+    JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(schema, encoded, base64);
+    DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>(schema);
+    GenericRecord record = datumReader.read(null, jsonDecoder);
+    String actual = record.toString();
+    String expected = "{\"AddressList\": [{\"label\": \"Kaa website\", \"url\": \"http://www.kaaproject.org\", \"__uuid\": [-32, 1, -89, -17, -127, 121, 73, -29, -69, 103, 63, -33, -14, -11, 44, 23]}, {\"label\": \"Kaa GitHub repository\", \"url\": \"https://github.com/kaaproject/kaa\", \"__uuid\": [125, 26, 26, -98, 19, -93, 68, -59, -69, 8, 101, 22, 87, 101, 8, -16]}, {\"label\": \"Kaa docs\", \"url\": \"http://docs.kaaproject.org/display/KAA/Kaa+IoT+Platform+Home\", \"__uuid\": [-94, 92, -117, -26, 102, -69, 74, -110, -109, -111, 25, -35, 63, 74, -7, 34]}, {\"label\": \"Kaa configuration design reference\", \"url\": \"http://docs.kaaproject.org/display/KAA/Configuration\", \"__uuid\": [33, -39, 112, 81, 24, 105, 78, 121, -107, 83, 106, -127, -89, 127, 36, -126]}, {\"label\": \"Hello world\", \"url\": \"http://hello.world\", \"__uuid\": [56, 63, 8, 63, -114, -48, 79, 55, -105, -118, -26, 118, -98, 124, 63, -103]}], \"__uuid\": [74, -25, 93, -113, 58, -74, 64, 2, -122, 62, 110, 94, -1, 16, -41, -39]}";
+    Assert.assertNotNull("Resulting string shouldn't be null", actual);
+    Assert.assertEquals("Actual result of encoding is not equal to expected", expected, actual);
+  }
+
 }

--- a/lang/java/avro/src/test/java/org/apache/avro/io/TestJsonDecoder.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/io/TestJsonDecoder.java
@@ -68,7 +68,7 @@ public class TestJsonDecoder {
     JsonDecoder jsonDecoder = DecoderFactory.get().jsonDecoder(schema, encoded, base64);
     DatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>(schema);
     GenericRecord record = datumReader.read(null, jsonDecoder);
-    String actual = record.toString();
+    String actual = record.toString().replaceAll("\\\\", "");
     String expected = "{\"AddressList\": [{\"label\": \"Kaa website\", \"url\": \"http://www.kaaproject.org\", \"__uuid\": [-32, 1, -89, -17, -127, 121, 73, -29, -69, 103, 63, -33, -14, -11, 44, 23]}, {\"label\": \"Kaa GitHub repository\", \"url\": \"https://github.com/kaaproject/kaa\", \"__uuid\": [125, 26, 26, -98, 19, -93, 68, -59, -69, 8, 101, 22, 87, 101, 8, -16]}, {\"label\": \"Kaa docs\", \"url\": \"http://docs.kaaproject.org/display/KAA/Kaa+IoT+Platform+Home\", \"__uuid\": [-94, 92, -117, -26, 102, -69, 74, -110, -109, -111, 25, -35, 63, 74, -7, 34]}, {\"label\": \"Kaa configuration design reference\", \"url\": \"http://docs.kaaproject.org/display/KAA/Configuration\", \"__uuid\": [33, -39, 112, 81, 24, 105, 78, 121, -107, 83, 106, -127, -89, 127, 36, -126]}, {\"label\": \"Hello world\", \"url\": \"http://hello.world\", \"__uuid\": [56, 63, 8, 63, -114, -48, 79, 55, -105, -118, -26, 118, -98, 124, 63, -103]}], \"__uuid\": [74, -25, 93, -113, 58, -74, 64, 2, -122, 62, 110, 94, -1, 16, -41, -39]}";
     Assert.assertNotNull("Resulting string shouldn't be null", actual);
     Assert.assertEquals("Actual result of encoding is not equal to expected", expected, actual);

--- a/lang/java/compiler/pom.xml
+++ b/lang/java/compiler/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/ipc/pom.xml
+++ b/lang/java/ipc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/mapred/pom.xml
+++ b/lang/java/mapred/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/maven-plugin/pom.xml
+++ b/lang/java/maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.avro</groupId>
     <artifactId>avro-toplevel</artifactId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/lang/java/pom.xml
+++ b/lang/java/pom.xml
@@ -60,6 +60,7 @@
     <ant.version>1.8.2</ant.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-compress.version>1.4.1</commons-compress.version>
+    <commons-codec.version>1.9</commons-codec.version>
     <easymock.version>3.0</easymock.version>
     <hamcrest.version>1.1</hamcrest.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
@@ -389,6 +390,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
         <version>${commons-compress.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${commons-codec.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/lang/java/protobuf/pom.xml
+++ b/lang/java/protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/thrift/pom.xml
+++ b/lang/java/thrift/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/thrift/src/main/java/org/apache/avro/thrift/ThriftData.java
+++ b/lang/java/thrift/src/main/java/org/apache/avro/thrift/ThriftData.java
@@ -101,8 +101,10 @@ public class ThriftData extends GenericData {
     if (fields == null) {                           // cache miss
       fields = new TFieldIdEnum[s.getFields().size()];
       Class c = r.getClass();
-      for (TFieldIdEnum f : FieldMetaData.getStructMetaDataMap(c).keySet())
+      for (Object o : FieldMetaData.getStructMetaDataMap(c).keySet()) {
+        TFieldIdEnum f = (TFieldIdEnum) o;
         fields[s.getField(f.getFieldName()).pos()] = f;
+      }
       fieldCache.put(s, fields);                  // update cache
     }
     return fields;
@@ -169,8 +171,8 @@ public class ThriftData extends GenericData {
           schema = Schema.createRecord(c.getName(), null, null,
                                        Throwable.class.isAssignableFrom(c));
           List<Field> fields = new ArrayList<Field>();
-          for (FieldMetaData f :
-                 FieldMetaData.getStructMetaDataMap(c).values()) {
+          for (Object o : FieldMetaData.getStructMetaDataMap(c).values()) {
+            FieldMetaData f = (FieldMetaData) o;
             Schema s = getSchema(f.valueMetaData);
             if (f.requirementType == TFieldRequirementType.OPTIONAL
                 && (s.getType() != Schema.Type.UNION))

--- a/lang/java/tools/pom.xml
+++ b/lang/java/tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/avro/pom.xml
+++ b/lang/java/trevni/avro/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/core/pom.xml
+++ b/lang/java/trevni/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/lang/java/trevni/doc/pom.xml
+++ b/lang/java/trevni/doc/pom.xml
@@ -22,13 +22,13 @@
   <parent>
     <artifactId>trevni-java</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>..</relativePath>
   </parent>
 
   <groupId>org.apache.avro</groupId>
   <artifactId>trevni-doc</artifactId>
-  <version>1.7.5</version>
+  <version>1.7.5-KAA</version>
   <packaging>pom</packaging>
 
   <name>Trevni Specification</name>

--- a/lang/java/trevni/pom.xml
+++ b/lang/java/trevni/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>avro-parent</artifactId>
     <groupId>org.apache.avro</groupId>
-    <version>1.7.5</version>
+    <version>1.7.5-KAA</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,20 @@
               </target>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,19 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>repository</id>
+      <distributionManagement>
+        <repository>
+          <id>kaa.release</id>
+          <url>http://repository.kaaproject.org/repository/internal/</url>
+        </repository>
+        <snapshotRepository>
+          <id>kaa.snapshots</id>
+          <url>http://repository.kaaproject.org/repository/snapshots/</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>org.apache.avro</groupId>
   <artifactId>avro-toplevel</artifactId>
-  <version>1.7.5</version>
+  <version>1.7.5-KAA</version>
   <packaging>pom</packaging>
 
   <name>Apache Avro Toplevel</name>


### PR DESCRIPTION
KAA-1655: Fix unescaped binary data in resulting string of org.apache.avro.generic.GenericData.toString() method.
This is copy of PR #6 .